### PR TITLE
SOP-428: Updates to utilise PHP7.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-Webhop - PHP5 Ansible Role
+Webhop - PHP7 Ansible Role
 ==========================
 
-Installs the latest PHP5 and associated packages on an ubuntu host.
+Installs the latest PHP7 and associated packages on an ubuntu host.
 Automatically dimension max_children limit on startup time.
 
 ## Role Variables
 
 ##### Defaults
 
-- `php_version` - The version of PHP to install. (**5.6**)
+- `php_version` - The version of PHP to install. (**7.2**)
 - `php_post_max_size` - Max size (in Mb) for POST requests. (**30**)
 - `php_upload_max_filesize` - Max size (in Mb) for uploads. (**30**)
 - `php_pm_max_children` - FPM max children. (**10**)
@@ -18,7 +18,7 @@ Automatically dimension max_children limit on startup time.
 - `scripts_owner` - User to chown the scripts (**ubuntu**)
 - `scripts_group` - Group to chown the scripts (**ubuntu**)
 - `fpm_total_ram_slice` - Ratio/slice of memory allocated to PHP-FPM (**0.4**)
-- `fpm_confpath` - PHP-FPM configuration file path (**/etc/php5/fpm/pool.d/www.conf**)
+- `fpm_confpath` - PHP-FPM configuration file path (**/etc/php/7.2/fpm/pool.d/www.conf**)
 - `fpm_avgmem` - Average memory footprint of a PHP-FPM child thread (**128**)
 - `enable_fpm_stats` - Enables the fpm status endpoint (**true**)
 - `php_pm_status_path` - Endpoint to expose fpm stats on (**/fpm-status**)
@@ -28,22 +28,22 @@ Usage
 
 ```yaml
 roles:
-    - { role: webhop.php5, fpm_avgmem: 90 }
+    - { role: webhop.php7, fpm_avgmem: 90 }
 ```
 
 To enable FPM stats:
 
 ```yaml
 roles:
-    - { role; webhop.php5, enable_fpm_stats: True }
+    - { role; webhop.php7, enable_fpm_stats: True }
 ```
 
 **Note** - You will also need to add the following snippet to your apache vhost (or nginx equivalent) to expose the status endpoint:
 
 ```text
 <LocationMatch '/fpm-status'>
-    SetHandler php5-fcgi-virt
-    Action php5-fcgi-virt /php5-fcgi virtual
+    SetHandler php7-fcgi-virt
+    Action php7-fcgi-virt /php7-fcgi virtual
 </LocationMatch>
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,8 @@ php_upload_max_filesize: 30
 php_memory_limit: 512
 php_max_input_vars: 2500
 php_pm_max_children: 10
-php_fpm_confpath: '/etc/php/7.1/fpm/php.ini'
-php_fpm_pool_confpath: '/etc/php/7.1/fpm/pool.d/www.conf'
+php_fpm_confpath: "/etc/php/{{ php_version }}/fpm/php.ini"
+php_fpm_pool_confpath: "/etc/php/{{ php_version }}/fpm/pool.d/www.conf"
 
 # FPM values for monitoring support
 enable_fpm_stats: false
@@ -21,5 +21,5 @@ scripts_group: root
 
 # FPM default values for automatic dimensioning of max_children
 fpm_total_ram_slice: 0.4
-fpm_confpath: '/etc/php5/fpm/pool.d/www.conf'
+fpm_confpath: "/etc/php/{{ php_version }}/fpm/pool.d/www.conf"
 fpm_avgmem: 128

--- a/files/fpm_dimensioning.py
+++ b/files/fpm_dimensioning.py
@@ -21,7 +21,7 @@ def get_php_fpm_memory(php_fpm_total_ram_slice=0.4):
     return mem_megs * php_fpm_total_ram_slice
 
 @argh.arg("--memratio", help="Slice or ratio of RAM allocated to PHP-FPM. 0 means no RAM, 1 means all the RAM available. Defaults to 0.4.", default=0.4)
-@argh.arg("--confpath", help="Pool configuration file path. Defaults to /etc/php5/fpm/pool.d/www.conf.", default="/etc/php5/fpm/pool.d/www.conf")
+@argh.arg("--confpath", help="Pool configuration file path. Defaults to /etc/php/7.2/fpm/pool.d/www.conf.", default="/etc/php/7.2/fpm/pool.d/www.conf")
 @argh.arg("--avgmem", help="Estimated safe average memory per thread (in megs). Defaults to 128.", default=128)
 def write_max_children_config(**kwargs):
     '''Overwrites the max children value in the default PHP-FPM config

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Chris Warren
-  description: Installs the latest PHP5 and associated packages on an ubuntu host
+  description: Installs the latest PHP7 and associated packages on an ubuntu host
   company: Beamly Ltd
   license: MIT
   min_ansible_version: 1.8

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,29 +10,34 @@
 - name: Install php packages
   apt: name={{ item }} state=present
   with_items:
-    - php7.1
-    - php7.1-common
-    - php7.1-mysqlnd
-    - php7.1-xmlrpc
-    - php7.1-xml
-    - php7.1-bcmath
-    - php7.1-bz2
-    - php7.1-curl
-    - php7.1-gd
-    - php7.1-cli
-    - php7.1-fpm
-    - php7.1-dev
+    - "php{{ php_version }}"
+    - "php{{ php_version }}-common"
+    - "php{{ php_version }}-mysqlnd"
+    - "php{{ php_version }}-xmlrpc"
+    - "php{{ php_version }}-xml"
+    - "php{{ php_version }}-bcmath"
+    - "php{{ php_version }}-bz2"
+    - "php{{ php_version }}-curl"
+    - "php{{ php_version }}-gd"
+    - "php{{ php_version }}-cli"
+    - "php{{ php_version }}-fpm"
+    - "php{{ php_version }}-dev"
+    - "php{{ php_version }}-imap"
+    - "php{{ php_version }}-dom"
+    - "php{{ php_version }}-mbstring"
+    - "php{{ php_version }}-sqlite3"
+    - "php{{ php_version }}-zip"
+    - "php{{ php_version }}-dba"
+    - "php{{ php_version }}-soap"
     - php-pear
-    - php7.1-imap
-    - php7.1-mcrypt
-    - php7.1-dom
-    - php7.1-mbstring
     - php-memcache
-    - php7.1-sqlite3
-    - php7.1-zip
-    - php7.1-dba
-    - php7.1-soap
     - php-memcached
+
+- name: Install php-mcrypt where the version is less than php7.2
+  apt: name={{ item }} state=present
+  with_items:
+    - "php{{ php_version }}-mcrypt"
+  when: php_version | version_compare('7.2', '<')
 
 - name: Install php-uuid if not on ubuntu precise
   apt:

--- a/templates/systemd/fpm_dimensioning.service.j2
+++ b/templates/systemd/fpm_dimensioning.service.j2
@@ -3,9 +3,9 @@ Description=Unit for PHP-FPM dimensioning
 {% if systemd_wants is defined %}
 Wants={{ systemd_wants | join(' ') }}
 {% else %}
-Wants=php5.6-fpm.service
+Wants=php{{ php_version }}-fpm.service
 {% endif %}
-After=php5.6-fpm.service
+After=php{{ php_version }}-fpm.service
 
 [Service]
 Type=oneshot

--- a/templates/upstart/fpm_dimensioning.conf.j2
+++ b/templates/upstart/fpm_dimensioning.conf.j2
@@ -6,7 +6,7 @@ description "upstart task for PHP-FPM dimensioning"
 {% if upstart_events is defined %}
 start on ( {{ upstart_events | join(' and ') }} )
 {% else %}
-start on stopped php-fpm5.6
+start on stopped php-fpm{{ php_version }}
 {% endif %}
 
 task
@@ -18,4 +18,3 @@ script
     {{ virtualenv_dir }}/php/bin/python {{ scripts_dir }}/php/fpm_dimensioning.py --memratio {{ fpm_total_ram_slice }} --confpath {{ php_fpm_pool_confpath }} --avgmem {{ fpm_avgmem }}
     echo "$(date ${DATE_FORMAT}) - Finished PHP-FPM tasks..."
 end script
-


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-428

Updates our installations to be able to use PHP7.2 (currently using PHP7.1).

Should be merged together with https://github.com/webhop/ansible-apache2-pagespeed/pull/34 and https://github.com/webhop/ansible-php-xdebug/pull/1

Also note, due to the default not always having been PHP7 ~ a lot of the pipelines specify the PHP socket path directly (as in, they look for PHP7.1) so this will need to be rolled out everywhere after merging this PR;
https://github.com/cotyinc/opi-site/blob/26e0c4dc726cf36f4f2b3bed9f386312732e0bd4/ansible/site.yml#L65

Also ... https://github.com/webhop/ansible-php-xdebug/blob/master/defaults/main.yml#L3 this will need changing too (or maybe it can just gain a value by other means?)

Also ... https://www.drupal.org/project/rules/issues/2923477 ensure that the Rules module is using the latest version (or applies this patch), as the PHP warning it used to generate, is now a fatal error...

With passing `php_version: "7.1"`:
<img width="1302" alt="screenshot 2019-01-09 at 15 05 33" src="https://user-images.githubusercontent.com/1250035/50910223-4b3ac900-1425-11e9-80d1-47c5fa75ce4d.png">

<img width="787" alt="screenshot 2019-01-09 at 15 31 08" src="https://user-images.githubusercontent.com/1250035/50910226-4c6bf600-1425-11e9-98a4-d7fa10bc5083.png">

With defaults:
<img width="1304" alt="screenshot 2019-01-09 at 15 41 22" src="https://user-images.githubusercontent.com/1250035/50910201-3fe79d80-1425-11e9-8c67-ba055cd40a16.png">

<img width="780" alt="screenshot 2019-01-09 at 10 12 52" src="https://user-images.githubusercontent.com/1250035/50892767-29c2e880-13f7-11e9-9fba-77f51a7342c9.png">

![screenshot 2019-01-09 at 12 04 07](https://user-images.githubusercontent.com/1250035/50898310-b0cb8d00-1406-11e9-8bd2-411959b5e6b3.png)

![screenshot 2019-01-09 at 12 04 35](https://user-images.githubusercontent.com/1250035/50898332-bfb23f80-1406-11e9-98d7-b271bc4e70c7.png)
