### PR TITLE
Issue with fpm_dimensioning naming.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,7 +164,10 @@
       owner: root
       group: root
 
-  - name: enable PHP-FPM dimensioning service (systemd)
-    shell: /bin/systemctl enable fpm_dimensioning
+  - name: Enable PHP-FPM dimensioning service (systemd)
+    shell: "/bin/systemctl enable fpm_dimensioning.service"
+
+  - name: Start oneshot fpm_dimensioning service for this session (systemd)
+    shell: "/bin/systemctl start fpm_dimensioning.service"
 
   when: ansible_lsb.major_release|int >= 16


### PR DESCRIPTION
...and also, "enable" just means the service will run on a reboot.  So it isn't actually applying it when provisioning the box.