### PR TITLE
Addresses some bad regexp which meant the pool status path was never exposed.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
   lineinfile:
     state: present
     dest: "{{ php_fpm_pool_confpath }}"
-    regexp: "^pm.status_path = .*$"
+    regexp: "^;?pm.status_path = .*$"
     line: "pm.status_path = {{ php_pm_status_path | default('/fpm-status')}}"
   when: enable_fpm_stats
 


### PR DESCRIPTION
```
; Note: The value must start with a leading slash (/). The value can be
;       anything, but it may not be a good idea to use the .php extension or it
;       may conflict with a real PHP file.
; Default Value: not set
;pm.status_path = /status
```