### PR TITLE
SOP-936: A dependency is installing php 7.3 instead of 7.2...

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,12 @@
     - "php-uploadprogress"
   when: php_version | version_compare('7.2', '>=')
 
+- name: "Ensure use of PHP{{ php_version }} after installing php-uploadprogress"
+  alternatives:
+    name: php
+    path: "/usr/bin/php{{ php_version }}"
+  when: php_version | version_compare('7.0', '>=')
+
 - name: Install php-uuid if not on ubuntu precise
   apt:
     name: php-uuid


### PR DESCRIPTION
https://beamly.atlassian.net/browse/SOP-936
https://beamly.atlassian.net/browse/CR-634

PHP installs via a means of update-alternatives, unfortunately ... php-uploadprogress activates php7.3 when it installs ... however, there's no harm in forcing it to use the same version on installation.

Both this and https://github.com/webhop/ansible-apache2-pagespeed/pull/42 are necessary.