### PR TITLE
Adds PECL support.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,9 @@ scripts_group: root
 fpm_total_ram_slice: 0.4
 fpm_confpath: "/etc/php/{{ php_version }}/fpm/pool.d/www.conf"
 fpm_avgmem: 128
+
+# Pecl related values
+php_pecl_install_pecl: false
+php_pecl_install_command: "pecl install"
+# Add extensions to this list to have them installed with this role.
+php_pecl_extensions: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,6 +86,20 @@
 - name: Set sendmail path
   lineinfile: dest="{{ php_fpm_confpath }}" regexp=";?\s*sendmail_path = .*$" line="sendmail_path = {{ php_sendmail_path | default('/usr/sbin/sendmail -t -i') }}"
 
+- name: Ensure pecl is installed (if configured).
+  package:
+    name: php-pear
+    state: present
+  when: php_pecl_install_pecl
+
+- name: Install PECL libaries.
+  shell: "yes '' | {{ php_pecl_install_command }} {{ item }}"
+  register: pecl_result
+  changed_when: pecl_result is succeeded
+  failed_when: "not (('already installed' in pecl_result.stdout) or ('install ok:' in pecl_result.stdout))"
+  with_items: "{{ php_pecl_extensions }}"
+  when: php_pecl_install_pecl and php_pecl_extensions
+
 - name: Enable status endpoint
   lineinfile:
     state: present


### PR DESCRIPTION
Based on https://github.com/geerlingguy/ansible-role-php-pecl (but without the dependency on geerlingguy/ansible-php7!)

### Using;
```
    - { role: webhop.php7,
        php_pecl_install_pecl: true,
        php_pecl_extensions: { jsmin },
      }
```
### First run;
<img width="647" alt="Screenshot 2019-08-28 at 16 23 03" src="https://user-images.githubusercontent.com/1250035/63869512-28f3bc80-c9b0-11e9-8473-e70721209db7.png">

### Rerun/ provision;
<img width="728" alt="Screenshot 2019-08-28 at 14 14 30" src="https://user-images.githubusercontent.com/1250035/63858867-36a04680-c99e-11e9-9e22-7c5a457e7ecb.png">

### Using (i.e. _off_!);
```
    - { role: webhop.php7 }
```
<img width="644" alt="Screenshot 2019-08-28 at 16 38 48" src="https://user-images.githubusercontent.com/1250035/63870684-58a3c400-c9b2-11e9-9e52-b3e303b5a6b7.png">
